### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -2,6 +2,8 @@ name: Content Freshness
 on:
   schedule: [{ cron: '0 9 1 * *' }]
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   freshness:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bh-asbm/ASBM_Knowledge-Base/security/code-scanning/2](https://github.com/bh-asbm/ASBM_Knowledge-Base/security/code-scanning/2)

To fix the problem, introduce a `permissions` key with the least required privileges either at the workflow root (affecting all jobs), or at the job level. The best place is at the workflow root, before the `jobs:` key. Given the job only reads contents and runs a script, `contents: read` is the minimal necessary permission. No other changes are needed: add the following block at the root of the workflow, between the `name:` and `on:` keys or after `on:` and before `jobs:`. No imports, methods, or additional modifications are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
