### PR TITLE
Potential fix for code scanning alert no. 197: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,4 +1,6 @@
 name: PR CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bh-asbm/ASBM_Knowledge-Base/security/code-scanning/197](https://github.com/bh-asbm/ASBM_Knowledge-Base/security/code-scanning/197)

To resolve this issue, we need to explicitly add a `permissions:` block to the workflow. The correct place is at the top-level (root) of `.github/workflows/pr-ci.yml`, unless a job requires a different set. In this workflow, none of the steps shown require anything but read access to repository contents: there are no steps involving writing to repository contents, pull requests, issues, or releases. Therefore, we should add at the root:

```yaml
permissions:
  contents: read
```

This should be placed immediately below the `name: PR CI` definition, and above the `on:` block. No extra imports, dependencies, or file edits are required. Only this addition is necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
